### PR TITLE
Fix trimage.desktop grammar

### DIFF
--- a/desktop/trimage.desktop
+++ b/desktop/trimage.desktop
@@ -7,4 +7,4 @@ Type=Application
 Exec=trimage
 Categories=Application;Qt;Graphics;
 StartupNotify=true
-Keywords=compression,compressor,images,jpg,jpeg,png,web
+Keywords=compression;compressor;images;jpg;jpeg;png;web;


### PR DESCRIPTION
According to https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s04.html , Keywords should be split by semicolons, not commas.