### PR TITLE
Remove unreachable shutdown code

### DIFF
--- a/trimage/ThreadPool/ThreadPool.py
+++ b/trimage/ThreadPool/ThreadPool.py
@@ -30,9 +30,6 @@ class ThreadPoolMixIn:
     def __init__(self, threadpool=None):
         if (threadpool == None):
             threadpool = ThreadPool()
-            self.__private_threadpool = True
-        else:
-            self.__private_threadpool = False
 
         self.__threadpool = threadpool
 
@@ -51,10 +48,6 @@ class ThreadPoolMixIn:
 
     def process_request(self, request, client_address):
         self.__threadpool.add_job(self.process_request_thread, [request, client_address])
-
-    def shutdown(self):
-        if (self.__private_threadpool): self.__threadpool.shutdown()
-
 
 class AddJobException(Exception):
     '''

--- a/trimage/trimage.py
+++ b/trimage/trimage.py
@@ -409,9 +409,6 @@ class Worker(QThread):
         self.toDisplay = Queue()
         self.threadpool = ThreadPool(max_workers=cpu_count())
 
-    def __del__(self):
-        self.threadpool.shutdown()
-
     def compress_file(self, images, showapp, verbose, imagelist):
         """Start the worker thread."""
         for image in images:


### PR DESCRIPTION
* Implementing `__del__` is discouraged
  * Imports (i.e. `import logging`) are cleaned up, leading to NoneType related errors
* When running via GUI mode, the shutdown code is never reached; we can let Python's internal GC clean everything